### PR TITLE
PLAY STATE output + play press-guard + GP wiring docs (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,30 @@ The THRU MUTE switch is also useful when the user wants to play a reverse solo l
 
 The OUTPUT LEVEL roller on the front panel of the Boomerang Phrase Sampler controls the playback volume but has no effect on the through signal. The output level can be adjusted at any time and is not stored in memory. The OUTPUT LEVEL roller is a high quality, sealed potentiometer and is very smooth in operation. The output level can be adjusted from zero to full output and is very useful for balancing the loop with the through signal. The OUTPUT LEVEL roller is also useful for setting the level of the loop signal when the THRU MUTE switch is turned off and only the loop signal is present.
 
+# Gig Performer Integration
+
+The plugin exposes its controls as host parameters, so any host (Gig Performer, a DAW, etc.) can map widgets to them. There are two kinds of parameter:
+
+- **Input params** — `play`, `record`, `once`, `stack`, `thruMute`, `reverse`. These act on a press; the plugin runs the corresponding button logic when they change.
+- **State output params** (read-only) — `playState`, `onceState`, `slowMode`, `loopCycle`. The plugin pushes these out whenever its internal state changes, so a widget mapped to one always reflects the device's true state.
+
+## Buttons should be Momentary
+
+The physical Boomerang switches are momentary, and the plugin engine — not the widget — holds the latched state (playing/stopped, once on/off). So configure the control widgets (`play`, `once`, `record`, `stack`) as **Momentary**:
+
+- Each press sends one edge, which the plugin treats as one button press and toggles its own state.
+- The release edge is ignored, so a press can't double-fire. (For example, pressing PLAY/STOP during recording stops recording without then starting playback.)
+
+A latching/toggle widget will mis-fire, because every release also counts as a press.
+
+## Showing state without breaking the button
+
+A momentary button springs back, so it can't display the latched state itself — exactly like the hardware, where a separate LED shows the state next to the momentary footswitch.
+
+**How:** add a separate read-only display widget (e.g. a label) and map it to the matching state output param (`playState` for PLAY/STOP, `onceState` for ONCE). Size and position it over the LED area of the button widget so it reads as one control. The plugin keeps it in sync automatically.
+
+⚠️ **Do not "widget-link" a button to its state param.** A link is bidirectional: the engine's state push travels back through the link and writes the input param, which re-triggers the button logic — a feedback loop. Keep the button (input) and the display (output) as independent widgets.
+
 # MIDI Configuration
 
 As mentioned earlier, the plugin has MIDI capability. I have included the configuration file for the Paint Audio MIDI Captain as a reference, but you may have to build your own depending on your hardware.

--- a/Source/LooperEngine.cpp
+++ b/Source/LooperEngine.cpp
@@ -220,7 +220,10 @@ void LooperEngine::onOnceButtonPressed()
         {
             // Once when playing in once mode restarts at the beginning of the loop
             stopPlayback();
-            startPlayback();        
+            startPlayback();
+            // onceMode is unchanged here, so re-assert onceState so the ONCE
+            // widget re-syncs after its toggle press (issue #66)
+            setOnceMode(OnceMode::On);
         }
     }
     else if (state == LooperState::Stopped || state == LooperState::Recording)
@@ -337,10 +340,14 @@ void LooperEngine::startPlayback()
             ? static_cast<float>(activeSlot.length.load() - 1)
             : 0.0f);
         currentState.store(LooperState::Playing);
-        
+
         // Notify host that play button is on
         if (parameterNotifyCallback)
+        {
             parameterNotifyCallback(ParameterIDs::play, 1.0f);
+            // Dedicated read-only output for PLAY/STOP widget (issue #66)
+            parameterNotifyCallback(ParameterIDs::playState, 1.0f);
+        }
     }
 }
 
@@ -350,10 +357,14 @@ void LooperEngine::stopPlayback()
     
     activeSlot.isPlaying.store(false);
     currentState.store(LooperState::Stopped);
-    
+
     // Notify host that play button is off
     if (parameterNotifyCallback)
+    {
         parameterNotifyCallback(ParameterIDs::play, 0.0f);
+        // Dedicated read-only output for PLAY/STOP widget (issue #66)
+        parameterNotifyCallback(ParameterIDs::playState, 0.0f);
+    }
 }
 
 void LooperEngine::startOverdubbing()

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -173,7 +173,11 @@ void BoomerangAudioProcessor::parameterChanged(const juce::String& parameterID, 
     }
     else if (parameterID == ParameterIDs::play)
     {
-        looperEngine->onPlayButtonPressed();
+        // Act on the press edge only (momentary widget). Acting on both edges
+        // double-fires: e.g. PLAY/STOP during record would stop recording on
+        // press, then start playback on release (issue #66).
+        if (buttonPressed)
+            looperEngine->onPlayButtonPressed();
     }
     else if (parameterID == ParameterIDs::once)
     {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -56,6 +56,12 @@ juce::AudioProcessorValueTreeState::ParameterLayout BoomerangAudioProcessor::cre
         "Once State",
         false));  // read-only state indicator
 
+    // Play state indicator - on when playing (for external PLAY/STOP widget)
+    layout.add(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID(ParameterIDs::playState, 1),
+        "Play State",
+        false));  // read-only state indicator
+
     // Continuous parameters
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         juce::ParameterID(ParameterIDs::volume, 1),

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -20,6 +20,7 @@ namespace ParameterIDs
     const juce::String loopCycle  = "loopCycle";  // Pulses when loop wraps (for REC blink)
     const juce::String slowMode   = "slowMode";   // On when speed is half (SLOW LED)
     const juce::String onceState  = "onceState"; // On when Once mode is active (ONCE LED)
+    const juce::String playState  = "playState"; // On when playing (for PLAY/STOP widget)
 }
 
 //==============================================================================


### PR DESCRIPTION
Closes #66.

## Summary

Fixes PLAY/STOP (and ONCE) widget sync with Gig Performer by exposing dedicated state outputs and making the play button behave like the hardware momentary footswitch.

## Changes

- **`playState` read-only output param** — engine notifies it on every Playing↔Stopped transition (mirrors the existing `onceState`/`slowMode` pattern). A host widget mapped to it always reflects the device's true play state, including internal stops (e.g. Once-mode auto-stop).
- **ONCE restart re-sync** — re-assert `onceState` on the once-restart path, where `onceMode` is unchanged but the display needs to re-sync.
- **`play` press-edge guard** — `onPlayButtonPressed` fired on every parameter edge, so a momentary PLAY/STOP widget double-fired (pressing during record stopped recording on press, then started playback on release). Now acts on the press edge only, matching the `once` guard.
- **README** — new *Gig Performer Integration* section: input vs state-output params, why control widgets must be Momentary, displaying state with a separate overlaid read-only widget, and why button↔state widget links create a feedback loop.

## Required host wiring

- PLAY/STOP and ONCE widgets → **Momentary**, mapped to `play` / `once`.
- State display → separate read-only widget mapped to `playState` / `onceState`. **Do not widget-link** it to the button.

## Testing

Built universal (x86_64 + arm64) VST3/AU/Standalone. Verified in Gig Performer: record → press PLAY/STOP stops recording without starting playback; PLAY/STOP and ONCE state displays track the engine via the output params; overlaying a state label on the button widget's LED area shows correct state while the momentary button works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)